### PR TITLE
use HTTPS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hashify does not solve a problem, it poses a question: what becomes possible
 when one is able to store entire documents in URLs?
 
   - [Hashify overview](http://bit.ly/dXYxGU)
-  - [Hacker News thread](http://news.ycombinator.com/item?id=2464213)
+  - [Hacker News thread](https://news.ycombinator.com/item?id=2464213)
 
 
 ### Installation
@@ -19,7 +19,7 @@ when one is able to store entire documents in URLs?
 
         make
 
-4.  Install [nginx](http://nginx.com/).
+4.  Install [nginx](https://www.nginx.com/).
 
 5.  Create a symlink to nginx.conf from wherever nginx sites live. For example:
 
@@ -36,6 +36,6 @@ when one is able to store entire documents in URLs?
 
 ### localhost
 
-Hashify uses [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
+Hashify uses [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
 in its communication with bitly. Though browsers don't allow this on localhost,
-one can use <http://lvh.me> for testing (lvh.me resolves to localhost).
+one can use <https://lvh.me> for testing (lvh.me resolves to localhost).

--- a/extras/hashify
+++ b/extras/hashify
@@ -9,6 +9,7 @@
 require 'base64'
 require 'net/http'
 require 'pathname'
+require 'uri'
 
 require 'json' # `gem install json` if necessary
 
@@ -83,20 +84,19 @@ end
 # is raised if bitly returns a non-200 status code.
 def shorten url
   # Generate query string from parameters.
-  req = Net::HTTP::Get.new '/'
-  req.set_form_data(
-    :login => $bitly_username,
-    :apiKey => $bitly_api_key,
-    :longUrl => url,
+  uri = URI 'https://api-ssl.bitly.com/v3/shorten'
+  uri.query = URI.encode_www_form(
+    login: $bitly_username,
+    apiKey: $bitly_api_key,
+    longUrl: url,
   )
   # Send request to bitly.
-  req = Net::HTTP::Get.new "/v3/shorten?#{req.body}"
-  res = Net::HTTP.new('api.bitly.com').request req
-  res = JSON.parse res.body
-  unless (code = res['status_code']) == 200
+  res = Net::HTTP.get_response uri
+  rec = JSON.parse res.body
+  unless (code = rec['status_code']) == 200
     raise RuntimeError, "bad response from bitly (#{code})"
   end
-  res['data']
+  rec['data']
 end
 
 # Read the contents of the specified file to determine the body of the
@@ -124,7 +124,7 @@ hostname = 'hashify.me'
 hostname = 'docco.' + hostname if args[:docco]
 
 # Generate a Hashify URL from the file's contents and provided options.
-domain = "http://#{hostname}/"
+domain = "https://#{hostname}/"
 url = domain + encode(contents) + search
 
 max = 2048

--- a/nginx.conf.default
+++ b/nginx.conf.default
@@ -1,6 +1,17 @@
 server {
-    listen          80;
-    server_name     hashify.me;
-    root            <ROOT>;
-    rewrite         ^/(?:[A-Za-z0-9+/=]*|unpack:[A-Za-z0-9]+(?:,[A-Za-z0-9]+)*)$ /index.html last;
+    listen              80;
+    server_name         hashify.me;
+}
+
+server {
+    listen              443 ssl;
+    server_name         hashify.me;
+
+    root                <ROOT>;
+    rewrite             ^/(?:[A-Za-z0-9+/=]*|unpack:[A-Za-z0-9]+(?:,[A-Za-z0-9]+)*)$ /index.html last;
+
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
+    ssl_certificate     /path/to/hashify.me.crt;
+    ssl_certificate_key /path/to/hashify.me.key;
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "description": "Store entire documents in URLs",
   "author": "David Chambers <dc@davidchambers.me>",
-  "licenses": [{
-    "type": "BSD",
-    "url": "https://raw.github.com/hashify/hashify.me/master/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "https://raw.github.com/hashify/hashify.me/master/LICENSE"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/hashify/hashify.me.git"

--- a/src/coffee/share.coffee
+++ b/src/coffee/share.coffee
@@ -54,7 +54,7 @@ setShortUrl = (data) ->
   # history entry which interferes with navigation. Instead,
   # we create a new `iframe` as per [Nir Levy's suggestion][1].
   #
-  # [1]: http://nirlevy.blogspot.com/2007/09/avoding-browser-history-when-changing.html
+  # [1]: https://nirlevy.blogspot.com/2007/09/avoding-browser-history-when-changing.html
   wrapper.removeChild tweet if tweet?.parentNode
   tweet = document.createElement 'iframe'
   tweet.id = 'tweet'
@@ -66,7 +66,7 @@ setShortUrl = (data) ->
   # invalid value: this value is not displayed, but prevents
   # Twitter from including the long URL in the tweet text.
   tweet.src =
-    'http://platform.twitter.com/widgets/tweet_button.html' +
+    'https://platform.twitter.com/widgets/tweet_button.html' +
     '?count=none&related=hashify&url=foo&text=' +
     encodeURIComponent tweetText
   wrapper.insertBefore tweet, shorturl

--- a/src/coffee/utils.coffee
+++ b/src/coffee/utils.coffee
@@ -20,14 +20,14 @@ corsNotSupported = ->
     [cross-origin resource sharing][1].
 
 
-    [1]: http://en.wikipedia.org/wiki/Cross-Origin_Resource_Sharing
+    [1]: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
   '''
 
 sendRequest = (action, params, success) ->
   request = new XMLHttpRequest()
   try
     request.open 'GET',
-      "http://api.bitly.com/v3/#{action}?login=davidchambers&" +
+      "https://api-ssl.bitly.com/v3/#{action}?login=davidchambers&" +
       "apiKey=R_20d23528ed6381ebb614a997de11c20a&#{params}"
   catch error
     # NS_ERROR_DOM_BAD_URI

--- a/src/sass/hashify.sass
+++ b/src/sass/hashify.sass
@@ -343,7 +343,7 @@ a
         font-weight: normal
         font-size: 0.8em
       &[href^="/"]:after
-        content: " [http://hashify.me" attr(href) "]"
+        content: " [https://hashify.me" attr(href) "]"
     h1, h2, h3, h4, h5, h6
       page-break-after: avoid
     pre


### PR DESCRIPTION
In #8, @agentofuser suggested supporting HTTPS.

Earlier today I made some changes to the Nginx configuration. This pull request includes code changes which fix “mixed content” errors by switching to HTTPS for Bitly and Twitter requests. This pull request also updates reference links to use HTTPS where applicable.
